### PR TITLE
【リファクタリング】framer-motionをuseInView/CSSアニメーションに置き換え

### DIFF
--- a/app/components/Faq/FaqItem.tsx
+++ b/app/components/Faq/FaqItem.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 
 type Props = {
   question: string;
@@ -24,21 +23,12 @@ export default function FaqItem({ question, answer }: Props) {
           +
         </span>
       </div>
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.3 }}
-            className="overflow-hidden"
-          >
-            <p className="text-sm text-stone-600 pb-4 leading-relaxed">
-              {answer}
-            </p>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <div
+        className="overflow-hidden transition-all duration-300"
+        style={{ maxHeight: isOpen ? "200px" : "0px" }}
+      >
+        <p className="text-sm text-stone-600 pb-4 leading-relaxed">{answer}</p>
+      </div>
     </div>
   );
 }

--- a/app/components/KeyVisual/index.tsx
+++ b/app/components/KeyVisual/index.tsx
@@ -1,21 +1,36 @@
 "use client";
 
 import Image from "next/image";
-import { motion } from "framer-motion";
 import TelButton from "@components/TelButton";
 import FeatureBadge from "./FeatureBadge";
 
-export default function KeyVisual() {
-  const features = [
-    "🎤 歌い放題",
-    "🍺 飲み放題あり",
-    "🍱 食べ物持込OK",
-    "👥 貸切OK",
-    "📅 年中無休",
-  ];
+const fadeInStyle = (delay: number): React.CSSProperties => ({
+  animation: `fadeIn 0.6s ease forwards`,
+  animationDelay: `${delay}s`,
+  opacity: 0,
+});
 
+const features = [
+  "🎤 歌い放題",
+  "🍺 飲み放題あり",
+  "🍱 食べ物持込OK",
+  "👥 貸切OK",
+  "📅 年中無休",
+];
+
+export default function KeyVisual() {
   return (
     <section className="relative w-full h-[400px] md:h-[500px] bg-stone-900">
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * { animation: none !important; opacity: 1 !important; }
+        }
+      `}</style>
+
       <Image
         src="/images/stage.jpeg"
         alt="カラオケ喫茶コンパ ステージ"
@@ -28,57 +43,39 @@ export default function KeyVisual() {
       <div className="absolute inset-0 bg-black/55" />
 
       <div className="absolute inset-0 flex flex-col justify-center px-8 md:px-16 max-w-4xl mx-auto left-0 right-0">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.1 }}
+        <div
+          style={fadeInStyle(0.1)}
           className="inline-block bg-amber-400/30 border border-amber-300 text-amber-200 text-xs px-4 py-1 rounded-full mb-5 w-fit"
         >
           京橋駅徒歩圏内 · 20年以上の実績
-        </motion.div>
+        </div>
 
-        <motion.h1
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-3xl md:text-5xl font-bold text-white mb-3 leading-relaxed"
+        <h1
           style={{
+            ...fadeInStyle(0.2),
             fontFamily: "var(--font-noto-serif)",
             textShadow: "0 2px 8px rgba(0,0,0,0.5)",
           }}
+          className="text-3xl md:text-5xl font-bold text-white mb-3 leading-relaxed"
         >
           お昼から気軽に
           <br />
           歌えるお店
-        </motion.h1>
+        </h1>
 
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          className="text-sm text-amber-300 mb-6"
-        >
+        <p style={fadeInStyle(0.3)} className="text-sm text-amber-300 mb-6">
           アットホームな大人の社交場 · 昼12時から営業
-        </motion.p>
+        </p>
 
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-          className="flex flex-wrap gap-2 mb-8"
-        >
+        <div style={fadeInStyle(0.4)} className="flex flex-wrap gap-2 mb-8">
           {features.map((text) => (
             <FeatureBadge key={text}>{text}</FeatureBadge>
           ))}
-        </motion.div>
+        </div>
 
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.5 }}
-        >
+        <div style={fadeInStyle(0.5)}>
           <TelButton size="lg" />
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/app/components/SectionWrapper.tsx
+++ b/app/components/SectionWrapper.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { motion } from "framer-motion";
+import { FadeIn } from "@/app/components/ui/FadeIn";
 
 type Props = {
   children: React.ReactNode;
@@ -19,16 +17,14 @@ export default function SectionWrapper({
   };
 
   return (
-    <motion.section
+    <section
       id={id}
       data-layout="SectionWrapper"
       className={`${variantClass[variant]} border-b border-amber-100 py-16 px-6`}
-      initial={{ opacity: 0 }}
-      whileInView={{ opacity: 1 }}
-      transition={{ duration: 0.6, ease: "easeOut" }}
-      viewport={{ once: true, margin: "-50px" }}
     >
-      <div className="max-w-4xl mx-auto">{children}</div>
-    </motion.section>
+      <FadeIn>
+        <div className="max-w-4xl mx-auto">{children}</div>
+      </FadeIn>
+    </section>
   );
 }

--- a/app/components/ui/FadeIn.tsx
+++ b/app/components/ui/FadeIn.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useInView } from "@/app/hooks/useInView";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function FadeIn({ children, className = "" }: Props) {
+  const { ref, isInView } = useInView();
+
+  const prefersReducedMotion =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{
+        opacity: isInView ? 1 : 0,
+        transform:
+          isInView || prefersReducedMotion ? "none" : "translateY(24px)",
+        transition: prefersReducedMotion
+          ? "none"
+          : "opacity 0.6s ease, transform 0.6s ease",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/hooks/useInView.ts
+++ b/app/hooks/useInView.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from "react";
+
+type Options = {
+  rootMargin?: string;
+};
+
+export function useInView({ rootMargin = "0px 0px -100px 0px" }: Options = {}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          observer.unobserve(element);
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return { ref, isInView };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "karaoke-compa",
       "version": "0.1.0",
       "dependencies": {
-        "framer-motion": "^12.38.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -3639,33 +3638,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4995,21 +4967,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.36.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "framer-motion": "^12.38.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## 概要
framer-motionへの依存を除去し、標準APIとCSSアニメーションに置き換えた。

## 変更内容
- [x] `app/hooks/useInView.ts` を新規作成（Intersection Observer API）
- [x] `app/components/ui/FadeIn.tsx` を新規作成
- [x] `SectionWrapper.tsx` をframer-motion → FadeInに置き換え
- [x] `FaqItem.tsx` のアコーディオンをCSS transitionに置き換え
- [x] `KeyVisual/index.tsx` のアニメーションをCSSアニメーションに置き換え
- [x] `framer-motion` をアンインストール
- [x] `prefers-reduced-motion` 対応を追加

## 目的
- 外部ライブラリへの依存を減らす
- VRTのページ全体撮影を可能にする（prefers-reduced-motion対応）

## 確認事項
- [x] ローカルで表示・アニメーション確認済み