### PR TITLE
【アクセシビリティ】ALTテキスト改善・ARIA属性追加

### DIFF
--- a/app/components/sections/Gallery.tsx
+++ b/app/components/sections/Gallery.tsx
@@ -4,12 +4,15 @@ import SectionWrapper from "@ui/SectionWrapper";
 
 export default function Gallery() {
   const photos = [
-    { src: "/images/interior.jpeg", alt: "店内ソファ席" },
-    { src: "/images/stage2.jpeg", alt: "ステージ・照明" },
-    { src: "/images/counter.jpeg", alt: "カウンター席" },
-    { src: "/images/drinks.jpeg", alt: "ドリンク" },
-    { src: "/images/livedam.jpeg", alt: "LIVE DAM" },
-    { src: "/images/mic.jpeg", alt: "マイク" },
+    { src: "/images/interior.jpeg", alt: "カラオケ喫茶コンパの店内ソファ席" },
+    { src: "/images/stage2.jpeg", alt: "カラオケ喫茶コンパのステージと照明" },
+    { src: "/images/counter.jpeg", alt: "カラオケ喫茶コンパのカウンター席" },
+    {
+      src: "/images/drinks.jpeg",
+      alt: "カラオケ喫茶コンパで提供しているドリンク",
+    },
+    { src: "/images/livedam.jpeg", alt: "カラオケ機器 LIVE DAM" },
+    { src: "/images/mic.jpeg", alt: "カラオケ用マイク" },
   ];
 
   return (

--- a/app/components/sections/Price/PriceCard.tsx
+++ b/app/components/sections/Price/PriceCard.tsx
@@ -15,21 +15,30 @@ export default function PriceCard({
     <div
       data-layout="PriceCard"
       className="bg-amber-50 border border-amber-100 rounded-xl p-6"
+      aria-label={`${time} ${title}料金`}
     >
       <div className="text-xs text-amber-500 mb-2">{time}</div>
       <div className="text-base font-medium text-amber-800 mb-4">{title}</div>
-      <div className="flex justify-between text-sm py-2.5 border-t border-amber-100">
-        <span className="text-amber-700">セット料金</span>
-        <span className="text-stone-900 font-medium">
-          ¥{setPrice.toLocaleString()}
-        </span>
-      </div>
-      <div className="flex justify-between text-sm py-2.5 border-t border-amber-100">
-        <span className="text-amber-700">飲み放題</span>
-        <span className="text-stone-900 font-medium">
-          ¥{flatRatePrice.toLocaleString()}
-        </span>
-      </div>
+      <dl>
+        <div className="flex justify-between text-sm py-2.5 border-t border-amber-100">
+          <dt className="text-amber-700">セット料金</dt>
+          <dd
+            className="text-stone-900 font-medium"
+            aria-label={`セット料金 ${setPrice.toLocaleString()}円`}
+          >
+            ¥{setPrice.toLocaleString()}
+          </dd>
+        </div>
+        <div className="flex justify-between text-sm py-2.5 border-t border-amber-100">
+          <dt className="text-amber-700">飲み放題</dt>
+          <dd
+            className="text-stone-900 font-medium"
+            aria-label={`飲み放題 ${flatRatePrice.toLocaleString()}円`}
+          >
+            ¥{flatRatePrice.toLocaleString()}
+          </dd>
+        </div>
+      </dl>
       <div className="text-xs text-amber-400 mt-1">セット料金含む</div>
     </div>
   );


### PR DESCRIPTION
## 概要
画像のALTテキストの改善とARIA属性を追加してスクリーンリーダー対応を強化した。

## 変更内容
- [x] Gallery.tsx のALTテキストを具体的な文言に改善
- [x] PriceCard.tsx に `aria-label` を追加
- [x] PriceCard.tsx の価格情報を `dl/dt/dd` に変更しARIA対応

## 確認事項
- [x] ローカルで表示確認済み

## 関連
- #5 アクセシビリティ改善（aria-label・title・コントラスト）