### PR TITLE
【開発環境】FaqのStory作成・型/データ管理追加

### DIFF
--- a/app/components/sections/Faq/FaqItem.stories.tsx
+++ b/app/components/sections/Faq/FaqItem.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import FaqItem from "./FaqItem";
+import { faqs } from "@data/faq";
+
+const meta: Meta<typeof FaqItem> = {
+  title: "Sections/Faq/FaqItem",
+  component: FaqItem,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof FaqItem>;
+
+export const Default: Story = {
+  args: faqs[0],
+};

--- a/app/components/sections/Faq/FaqItem.tsx
+++ b/app/components/sections/Faq/FaqItem.tsx
@@ -1,13 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import type { FaqItem as FaqItemType } from "@defs/types";
 
-type Props = {
-  question: string;
-  answer: string;
-};
-
-export default function FaqItem({ question, answer }: Props) {
+export default function FaqItem({ question, answer }: FaqItemType) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/app/components/sections/Faq/index.tsx
+++ b/app/components/sections/Faq/index.tsx
@@ -1,30 +1,7 @@
 import SectionHeader from "@ui/SectionHeader";
 import SectionWrapper from "@ui/SectionWrapper";
 import FaqItem from "./FaqItem";
-
-const faqs = [
-  {
-    question: "団体でも可能ですか？",
-    answer: "はい、団体でも可能ですのでお気軽にお越しください。",
-  },
-  {
-    question: "カラオケの機種は何ですか？",
-    answer: "最新のLIVE DAMをご用意しております。",
-  },
-  {
-    question: "食べ物の持ち込みは可能ですか？",
-    answer: "飲食物の持ち込みも可能ですのでお気軽にお越しください。",
-  },
-  {
-    question: "飲み放題はありますか？",
-    answer:
-      "はい、単品メニューから飲み放題メニューをご用意しておりますので、ぜひお越しください。",
-  },
-  {
-    question: "キャッシュレス対応はしていますか？",
-    answer: "はい、ほぼ全てのキャッシュレス対応が可能です。",
-  },
-];
+import { faqs } from "@data/faq";
 
 export default function Faq() {
   return (

--- a/app/data/faq.ts
+++ b/app/data/faq.ts
@@ -1,0 +1,25 @@
+import type { FaqItem } from "@defs/types/faq";
+
+export const faqs: FaqItem[] = [
+  {
+    question: "団体でも可能ですか？",
+    answer: "はい、団体でも可能ですのでお気軽にお越しください。",
+  },
+  {
+    question: "カラオケの機種は何ですか？",
+    answer: "最新のLIVE DAMをご用意しております。",
+  },
+  {
+    question: "食べ物の持ち込みは可能ですか？",
+    answer: "飲食物の持ち込みも可能ですのでお気軽にお越しください。",
+  },
+  {
+    question: "飲み放題はありますか？",
+    answer:
+      "はい、単品メニューから飲み放題メニューをご用意しておりますので、ぜひお越しください。",
+  },
+  {
+    question: "キャッシュレス対応はしていますか？",
+    answer: "はい、ほぼ全てのキャッシュレス対応が可能です。",
+  },
+];

--- a/app/defs/types/faq.ts
+++ b/app/defs/types/faq.ts
@@ -1,0 +1,4 @@
+export type FaqItem = {
+  question: string;
+  answer: string;
+};

--- a/app/defs/types/index.ts
+++ b/app/defs/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./price";
+export * from "./faq";


### PR DESCRIPTION
## 概要
FaqセクションのStoryを作成し型とデータの管理構成を整備した。

## 変更内容
- [x] `app/defs/types/faq.ts` を作成しFaqItemの型を定義
- [x] `app/defs/types/index.ts` にre-exportを追加
- [x] `app/data/faq.ts` を作成しfaqsデータを一元管理
- [x] `FaqItem.tsx` の型をFaqItemTypeに変更
- [x] FaqItem・FaqのStory作成

## 残タスク（VRT導入時）
- [ ] FaqItemのOpen/Close状態をキャプチャするplay関数の追加

## 関連
- #25 Storybook導入