### PR TITLE
【開発環境】VRT差分があってもCIをFailにしない

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -31,8 +31,7 @@ jobs:
         run: npx vitest --project storybook run
 
       - name: Run reg-suit
-        run: npx reg-suit run || true
-        continue-on-error: true
+        run: npx reg-suit run
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx vitest --project storybook run
 
       - name: Run reg-suit
-        run: npx reg-suit run
+        run: npx reg-suit run || true
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/app/components/ui/SectionHeader/SectionHeader.stories.tsx
+++ b/app/components/ui/SectionHeader/SectionHeader.stories.tsx
@@ -1,18 +1,18 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import SectionHeader from './index'
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import SectionHeader from "./index";
 
 const meta: Meta<typeof SectionHeader> = {
-  title: 'UI/SectionHeader',
+  title: "UI/SectionHeader",
   component: SectionHeader,
-  tags: ['autodocs'],
-}
+  tags: ["autodocs"],
+};
 
-export default meta
-type Story = StoryObj<typeof SectionHeader>
+export default meta;
+type Story = StoryObj<typeof SectionHeader>;
 
 export const Default: Story = {
   args: {
-    label: 'gallery',
-    title: '店内の様子',
+    label: "gallery",
+    title: "店内の様子 ",
   },
-}
+};

--- a/app/components/ui/SectionHeader/SectionHeader.stories.tsx
+++ b/app/components/ui/SectionHeader/SectionHeader.stories.tsx
@@ -1,18 +1,18 @@
-import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import SectionHeader from "./index";
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import SectionHeader from './index'
 
 const meta: Meta<typeof SectionHeader> = {
-  title: "UI/SectionHeader",
+  title: 'UI/SectionHeader',
   component: SectionHeader,
-  tags: ["autodocs"],
-};
+  tags: ['autodocs'],
+}
 
-export default meta;
-type Story = StoryObj<typeof SectionHeader>;
+export default meta
+type Story = StoryObj<typeof SectionHeader>
 
 export const Default: Story = {
   args: {
-    label: "gallery",
-    title: "店内の様子 ",
+    label: 'gallery',
+    title: '店内の様子',
   },
-};
+}

--- a/regconfig.json
+++ b/regconfig.json
@@ -14,7 +14,7 @@
       "prComment": true,
       "prCommentBehavior": "default",
       "clientId": "$REG_SUIT_CLIENT_ID",
-      "failIfHasDifferences": false
+      "setCommitStatus": false
     },
     "reg-publish-s3-plugin": {
       "bucketName": "karaoke-compa-vrt-reports"

--- a/regconfig.json
+++ b/regconfig.json
@@ -13,7 +13,8 @@
     "reg-notify-github-plugin": {
       "prComment": true,
       "prCommentBehavior": "default",
-      "clientId": "$REG_SUIT_CLIENT_ID"
+      "clientId": "$REG_SUIT_CLIENT_ID",
+      "failIfHasDifferences": false
     },
     "reg-publish-s3-plugin": {
       "bucketName": "karaoke-compa-vrt-reports"


### PR DESCRIPTION
## 概要

VRTで差分が検出されてもCIをFailにしない。
合否の判断はレポートを確認して人間が行う。

## 対応

`regconfig.json` の `reg-notify-github-plugin` に `setCommitStatus: false` を追加。

## 関連

closes #42