### PR TITLE
【開発環境】VRT アニメーション無効化対応

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,9 @@
+/* VRT用: アニメーション・トランジション無効化 */
+*,
+*::before,
+*::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/nextjs-vite";
 import { Noto_Sans_JP, Noto_Serif_JP } from "next/font/google";
 import "../app/globals.css";
+import "./preview.css";
 
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans",
@@ -14,10 +15,30 @@ const notoSerifJP = Noto_Serif_JP({
   weight: ["400", "700"],
 });
 
-const preview: Preview = {
-  parameters: {
-    // ...既存のまま
+const parameters: Preview["parameters"] = {
+  controls: {
+    matchers: {
+      color: /(background|color)$/i,
+      date: /Date$/i,
+    },
   },
+  viewport: {
+    viewports: {
+      mobile: { name: "Mobile", styles: { width: "390px", height: "844px" } },
+      tablet: { name: "Tablet", styles: { width: "768px", height: "1024px" } },
+      desktop: {
+        name: "Desktop",
+        styles: { width: "1280px", height: "800px" },
+      },
+    },
+  },
+  a11y: {
+    test: "todo",
+  },
+};
+
+const preview: Preview = {
+  parameters,
   decorators: [
     (Story) => (
       <div className={`${notoSansJP.variable} ${notoSerifJP.variable}`}>

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,6 +1,13 @@
-import { afterEach, beforeEach } from "vitest";
+import { afterEach, beforeAll, beforeEach } from "vitest";
+import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
+
+beforeAll(() => {
+  vi.mock("@hooks/useInView", () => ({
+    useInView: () => ({ ref: { current: null }, isInView: true }),
+  }));
+});
 
 beforeEach(async () => {
   await page.viewport(1280, 720);


### PR DESCRIPTION
## 概要
VRT キャプチャ時にアニメーションが途中の状態でスクリーンショットが撮られる問題を修正する。

## 問題
- CSS アニメーション（`animate-fade-in` 等）がキャプチャ中に実行される
- `FadeIn` コンポーネントが `opacity-0` のままキャプチャされる

## 対応内容
- `.storybook/preview.css` を追加し CSS アニメーション・トランジションを無効化
- `.storybook/vitest.setup.ts` で `useInView` をモックし `isInView: true` を返すように設定

closes #44