### PR TITLE
【開発環境】VRT：変更なしPRでスナップショットがNewになる問題を修正

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -7,14 +7,52 @@ on:
     paths-ignore:
       - "**.md"
       - ".github/**"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - ".github/**"
+
 jobs:
   vrt:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run screenshots
+        run: npx vitest --project storybook run
+
+      - name: Run reg-suit
+        run: npx reg-suit run
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ap-northeast-3
+          REG_SUIT_CLIENT_ID: ${{ secrets.REG_SUIT_CLIENT_ID }}
+
+  update-base:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 概要
何も変更していないPRでも画像差分チェックがNewになってしまう問題を修正。

## 原因
mainブランチへのpush時にVRTが実行されておらず、S3にベーススナップショットが保存されていなかった。

## 対応
- `vrt.yml` に `push: branches: [main]` トリガーを追加
- mainへのpush時に `update-base` ジョブを実行し、S3にスナップショットを保存するようにした

## 確認方法
1. このPRをマージ
2. mainの `update-base` ジョブが完了するのを確認
3. 次のPRで `New` が出なくなることを確認