### PR TITLE
【開発環境】VRT：Desktop/Mobileプロジェクト分離とStory振り分け

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -35,7 +35,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run screenshots
-        run: npx vitest --project storybook --project storybook-mobile run
+        run: npx vitest --project storybook-mobile --project storybook-desktop run
 
       - name: Run reg-suit
         run: npx reg-suit run

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -35,7 +35,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run screenshots
-        run: npx vitest --project storybook run
+        run: npx vitest --project storybook --project storybook-mobile run
 
       - name: Run reg-suit
         run: npx reg-suit run

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,51 +1,48 @@
-import type { Preview } from "@storybook/nextjs-vite";
-import { Noto_Sans_JP, Noto_Serif_JP } from "next/font/google";
+import { useEffect } from "react";
+import type { StoryContext } from "@storybook/nextjs-vite";
 import "../app/globals.css";
 import "./preview.css";
 
-const notoSansJP = Noto_Sans_JP({
-  variable: "--font-noto-sans",
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-});
-
-const notoSerifJP = Noto_Serif_JP({
-  variable: "--font-noto-serif",
-  subsets: ["latin"],
-  weight: ["400", "700"],
-});
-
-const parameters: Preview["parameters"] = {
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/i,
-    },
-  },
-  viewport: {
-    viewports: {
-      mobile: { name: "Mobile", styles: { width: "390px", height: "844px" } },
-      tablet: { name: "Tablet", styles: { width: "768px", height: "1024px" } },
-      desktop: {
-        name: "Desktop",
-        styles: { width: "1280px", height: "800px" },
-      },
-    },
-  },
-  a11y: {
-    test: "todo",
-  },
+const viewports: Record<string, { width: string; height: string }> = {
+  mobile: { width: "390px", height: "844px" },
+  tablet: { width: "768px", height: "1024px" },
+  desktop: { width: "1280px", height: "800px" },
 };
 
-const preview: Preview = {
-  parameters,
-  decorators: [
-    (Story) => (
-      <div className={`${notoSansJP.variable} ${notoSerifJP.variable}`}>
-        <Story />
-      </div>
-    ),
-  ],
+const ViewportDecorator = (
+  Story: React.ComponentType,
+  context: StoryContext,
+) => {
+  const viewportKey = context.globals?.viewport?.value;
+  const size = viewportKey ? viewports[viewportKey] : null;
+
+  useEffect(() => {
+    if (size) {
+      const iframe = window.parent?.document.querySelector(
+        "iframe[data-vitest]",
+      );
+      const wrapper = iframe?.parentElement;
+      if (wrapper) {
+        wrapper.style.width = size.width;
+        wrapper.style.height = size.height;
+      }
+      document.body.style.width = size.width;
+      document.body.style.minHeight = size.height;
+    } else {
+      const iframe = window.parent?.document.querySelector(
+        "iframe[data-vitest]",
+      );
+      const wrapper = iframe?.parentElement;
+      if (wrapper) {
+        wrapper.style.width = "";
+        wrapper.style.height = "";
+      }
+      document.body.style.width = "";
+      document.body.style.minHeight = "";
+    }
+  }, [size]);
+
+  return <Story />;
 };
 
-export default preview;
+export const decorators = [ViewportDecorator];

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -10,7 +10,7 @@ beforeAll(() => {
 });
 
 beforeEach(async () => {
-  await page.viewport(1280, 720);
+  // ビューポートは Story の globals.viewportで制御する
 });
 
 afterEach(async (context) => {

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,16 +1,23 @@
-import { afterEach, beforeAll, beforeEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
 
-beforeAll(() => {
-  vi.mock("@hooks/useInView", () => ({
-    useInView: () => ({ ref: { current: null }, isInView: true }),
-  }));
-});
+vi.mock("@hooks/useInView", () => ({
+  useInView: () => ({ ref: { current: null }, isInView: true }),
+}));
 
-beforeEach(async () => {
-  // ビューポートはStoryのglobals.viewportで制御する
+beforeEach(async (context) => {
+  const projectName = context.task.file?.projectName ?? "";
+  const isMobileProject = projectName.includes("storybook-mobile");
+  const isDesktopStory = context.task.name.includes("Desktop");
+
+  if (isMobileProject && isDesktopStory) {
+    context.skip();
+  }
+  if (!isMobileProject && !isDesktopStory) {
+    context.skip();
+  }
 });
 
 afterEach(async (context) => {

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -3,14 +3,28 @@ import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
 
+const VIEWPORTS: Record<string, { width: number; height: number }> = {
+  mobile: { width: 390, height: 844 },
+  tablet: { width: 768, height: 1024 },
+  desktop: { width: 1280, height: 800 },
+};
+
+const DEFAULT_VIEWPORT = VIEWPORTS.desktop;
+
 beforeAll(() => {
   vi.mock("@hooks/useInView", () => ({
     useInView: () => ({ ref: { current: null }, isInView: true }),
   }));
 });
 
-beforeEach(async () => {
-  // ビューポートは Story の globals.viewportで制御する
+beforeEach(async (context) => {
+  const globals = (context.task.meta as Record<string, unknown>)
+    ?.storyGlobals as Record<string, unknown> | undefined;
+  const viewportKey = (globals?.viewport as { value?: string } | undefined)
+    ?.value;
+  const viewport =
+    (viewportKey ? VIEWPORTS[viewportKey] : undefined) ?? DEFAULT_VIEWPORT;
+  await page.viewport(viewport.width, viewport.height);
 });
 
 afterEach(async (context) => {

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -3,28 +3,14 @@ import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
 
-const VIEWPORTS: Record<string, { width: number; height: number }> = {
-  mobile: { width: 390, height: 844 },
-  tablet: { width: 768, height: 1024 },
-  desktop: { width: 1280, height: 800 },
-};
-
-const DEFAULT_VIEWPORT = VIEWPORTS.desktop;
-
 beforeAll(() => {
   vi.mock("@hooks/useInView", () => ({
     useInView: () => ({ ref: { current: null }, isInView: true }),
   }));
 });
 
-beforeEach(async (context) => {
-  const globals = (context.task.meta as Record<string, unknown>)
-    ?.storyGlobals as Record<string, unknown> | undefined;
-  const viewportKey = (globals?.viewport as { value?: string } | undefined)
-    ?.value;
-  const viewport =
-    (viewportKey ? VIEWPORTS[viewportKey] : undefined) ?? DEFAULT_VIEWPORT;
-  await page.viewport(viewport.width, viewport.height);
+beforeEach(async () => {
+  // ビューポートはStoryのglobals.viewportで制御する
 });
 
 afterEach(async (context) => {

--- a/app/components/layout/Footer/Footer.stories.tsx
+++ b/app/components/layout/Footer/Footer.stories.tsx
@@ -13,4 +13,10 @@ const meta: Meta<typeof Footer> = {
 export default meta;
 type Story = StoryObj<typeof Footer>;
 
-export const Default: Story = {};
+export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  globals: {
+    viewport: { value: "mobile" },
+  },
+};

--- a/app/components/layout/Footer/Footer.stories.tsx
+++ b/app/components/layout/Footer/Footer.stories.tsx
@@ -13,10 +13,4 @@ const meta: Meta<typeof Footer> = {
 export default meta;
 type Story = StoryObj<typeof Footer>;
 
-export const Desktop: Story = {};
-
-export const Mobile: Story = {
-  globals: {
-    viewport: { value: "mobile" },
-  },
-};
+export const Default: Story = {};

--- a/app/components/layout/Header/Header.stories.tsx
+++ b/app/components/layout/Header/Header.stories.tsx
@@ -15,4 +15,4 @@ type Story = StoryObj<typeof Header>;
 
 export const Default: Story = {};
 
-export const MenuOpen: Story = {};
+export const Desktop: Story = {};

--- a/app/components/layout/Header/Header.stories.tsx
+++ b/app/components/layout/Header/Header.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof Header> = {
 export default meta;
 type Story = StoryObj<typeof Header>;
 
-export const Default: Story = {};
+export const Desktop: Story = {};
 
-export const MenuOpen: Story = {};
+export const Mobile: Story = {
+  globals: {
+    viewport: { value: "mobile" },
+  },
+};

--- a/app/components/layout/Header/Header.stories.tsx
+++ b/app/components/layout/Header/Header.stories.tsx
@@ -13,10 +13,6 @@ const meta: Meta<typeof Header> = {
 export default meta;
 type Story = StoryObj<typeof Header>;
 
-export const Desktop: Story = {};
+export const Default: Story = {};
 
-export const Mobile: Story = {
-  globals: {
-    viewport: { value: "mobile" },
-  },
-};
+export const MenuOpen: Story = {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
             viewport: { width: 1280, height: 800 },
             output: {
               dir: "__screenshots__",
-              file: path.join("[file]", "desktop", "[name].png"),
+              file: path.join("[file]", "desktop-[name].png"),
             },
           }),
         ],
@@ -48,7 +48,7 @@ export default defineConfig({
             viewport: { width: 390, height: 844 },
             output: {
               dir: "__screenshots__",
-              file: path.join("[file]", "mobile", "[name].png"),
+              file: path.join("[file]", "mobile-[name].png"),
             },
           }),
         ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,11 +19,12 @@ export default defineConfig({
         extends: true,
         plugins: [
           storybookTest({ configDir: path.join(dirname, ".storybook") }),
+          // storybookプロジェクト
           storybookScreenshot({
             viewport: { width: 1280, height: 800 },
             output: {
-              dir: "__screenshots__/desktop",
-              file: path.join("[file]", "[name].png"),
+              dir: "__screenshots__",
+              file: path.join("[file]", "desktop", "[name].png"),
             },
           }),
         ],
@@ -42,11 +43,12 @@ export default defineConfig({
         extends: true,
         plugins: [
           storybookTest({ configDir: path.join(dirname, ".storybook") }),
+          // storybook-mobileプロジェクト
           storybookScreenshot({
             viewport: { width: 390, height: 844 },
             output: {
-              dir: "__screenshots__/mobile",
-              file: path.join("[file]", "[name].png"),
+              dir: "__screenshots__",
+              file: path.join("[file]", "mobile", "[name].png"),
             },
           }),
         ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,63 +6,45 @@ import { defineConfig } from "vitest/config";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import storybookScreenshot from "@storycap-testrun/browser/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
+import type { TestProjectConfiguration } from "vitest/config";
 
 const dirname =
   typeof __dirname !== "undefined"
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
+const createStorybookProject = (
+  name: string,
+  viewport: { width: number; height: number },
+): TestProjectConfiguration => ({
+  extends: true,
+  plugins: [
+    storybookTest({ configDir: path.join(dirname, ".storybook") }),
+    storybookScreenshot({
+      viewport,
+      output: {
+        dir: "__screenshots__",
+        file: path.join("[file]", `${name}-[name].png`),
+      },
+    }),
+  ],
+  test: {
+    name,
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright({}),
+      instances: [{ browser: "chromium" }],
+    },
+    setupFiles: [".storybook/vitest.setup.ts"],
+  },
+});
+
 export default defineConfig({
   test: {
     projects: [
-      {
-        extends: true,
-        plugins: [
-          storybookTest({ configDir: path.join(dirname, ".storybook") }),
-          // storybookプロジェクト
-          storybookScreenshot({
-            viewport: { width: 1280, height: 800 },
-            output: {
-              dir: "__screenshots__",
-              file: path.join("[file]", "desktop-[name].png"),
-            },
-          }),
-        ],
-        test: {
-          name: "storybook",
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: playwright({}),
-            instances: [{ browser: "chromium" }],
-          },
-          setupFiles: [".storybook/vitest.setup.ts"],
-        },
-      },
-      {
-        extends: true,
-        plugins: [
-          storybookTest({ configDir: path.join(dirname, ".storybook") }),
-          // storybook-mobileプロジェクト
-          storybookScreenshot({
-            viewport: { width: 390, height: 844 },
-            output: {
-              dir: "__screenshots__",
-              file: path.join("[file]", "mobile-[name].png"),
-            },
-          }),
-        ],
-        test: {
-          name: "storybook-mobile",
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: playwright({}),
-            instances: [{ browser: "chromium" }],
-          },
-          setupFiles: [".storybook/vitest.setup.ts"],
-        },
-      },
+      createStorybookProject("storybook-mobile", { width: 390, height: 844 }),
+      createStorybookProject("storybook-desktop", { width: 1280, height: 800 }),
     ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,10 +19,39 @@ export default defineConfig({
         extends: true,
         plugins: [
           storybookTest({ configDir: path.join(dirname, ".storybook") }),
-          storybookScreenshot(),
+          storybookScreenshot({
+            viewport: { width: 1280, height: 800 },
+            output: {
+              dir: "__screenshots__/desktop",
+              file: path.join("[file]", "[name].png"),
+            },
+          }),
         ],
         test: {
           name: "storybook",
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({}),
+            instances: [{ browser: "chromium" }],
+          },
+          setupFiles: [".storybook/vitest.setup.ts"],
+        },
+      },
+      {
+        extends: true,
+        plugins: [
+          storybookTest({ configDir: path.join(dirname, ".storybook") }),
+          storybookScreenshot({
+            viewport: { width: 390, height: 844 },
+            output: {
+              dir: "__screenshots__/mobile",
+              file: path.join("[file]", "[name].png"),
+            },
+          }),
+        ],
+        test: {
+          name: "storybook-mobile",
           browser: {
             enabled: true,
             headless: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ const createStorybookProject = (
       viewport,
       output: {
         dir: "__screenshots__",
-        file: path.join("[file]", `${name}-[name].png`),
+        file: path.join("[file]", `[name]-${name}.png`),
       },
     }),
   ],


### PR DESCRIPTION
## 概要
VRTのスクリーンショットをDesktop/Mobileで別プロジェクトに分離し、Story名で振り分けるように対応。

## 対応内容
- vitest.config.tsに `storybook-desktop`・`storybook-mobile` の2プロジェクトを追加
- `createStorybookProject` 関数でプロジェクト設定を共通化
- `storybook-desktop`：1280x800、`Desktop` を含むStoryのみ撮影
- `storybook-mobile`：390x844、`Desktop` 以外のStoryを撮影
- vrt.ymlの `Run screenshots` コマンドに両プロジェクトを追加
- vi.mockをトップレベルに移動（Vitest将来バージョンへの対応）

## 関連
#50