### PR TITLE
【修正】VRT キャプチャで KeyVisual・FadeIn の opacity-0 が解除されない問題を修正

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -7,3 +7,8 @@
   transition-duration: 0s !important;
   transition-delay: 0s !important;
 }
+
+/* VRT用: opacity-0 を表示状態に上書き */
+.opacity-0 {
+  opacity: 1 !important;
+}

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, beforeAll } from "vitest";
 import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
@@ -18,6 +18,12 @@ beforeEach(async (context) => {
   if (!isMobileProject && !isDesktopStory) {
     context.skip();
   }
+});
+
+beforeAll(() => {
+  vi.mock("@hooks/useInView", () => ({
+    useInView: () => ({ ref: { current: null }, isInView: true }),
+  }));
 });
 
 afterEach(async (context) => {

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, beforeAll } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { vi } from "vitest";
 import { page } from "vitest/browser";
 import { screenshot } from "@storycap-testrun/browser";
@@ -18,12 +18,6 @@ beforeEach(async (context) => {
   if (!isMobileProject && !isDesktopStory) {
     context.skip();
   }
-});
-
-beforeAll(() => {
-  vi.mock("@hooks/useInView", () => ({
-    useInView: () => ({ ref: { current: null }, isInView: true }),
-  }));
 });
 
 afterEach(async (context) => {


### PR DESCRIPTION
## 概要
VRT キャプチャ時に KeyVisual のテキスト・UIが非表示になる問題を修正する。

## 問題
- `animate-fade-in` + `opacity-0` の組み合わせで `animation-duration: 0s` 適用時にアニメーションが発火せず `opacity: 0` のままキャプチャされる

## 対応内容
- `.storybook/preview.css` に `.opacity-0 { opacity: 1 !important }` を追加