### PR TITLE
【機能追加】ハンバーガーメニュー開いた状態のVRT Story追加

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -9,6 +9,6 @@
 }
 
 /* VRT用: opacity-0 を表示状態に上書き */
-.opacity-0 {
+[data-layout="KeyVisual"] .opacity-0 {
   opacity: 1 !important;
 }

--- a/app/components/layout/Header/Header.stories.tsx
+++ b/app/components/layout/Header/Header.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { userEvent, within, waitFor } from "storybook/test";
+
 import Header from "./index";
 
 const meta: Meta<typeof Header> = {
@@ -18,5 +20,17 @@ export const Mobile: Story = {};
 export const Desktop: Story = {
   globals: {
     viewport: { value: "desktop" },
+  },
+};
+export const Mobile_Open: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: "メニューを開く" });
+    await userEvent.click(button);
+    await waitFor(() => {
+      const btn = canvas.getByRole("button", { name: "メニューを閉じる" });
+      if (!btn) throw new Error();
+    });
+    button.blur();
   },
 };

--- a/app/components/sections/KeyVisual/index.tsx
+++ b/app/components/sections/KeyVisual/index.tsx
@@ -7,7 +7,10 @@ import { features } from "@data/keyvisual";
 
 export default function KeyVisual() {
   return (
-    <section className="relative w-full h-[400px] md:h-[500px] bg-stone-900">
+    <section
+      data-layout="KeyVisual"
+      className="relative w-full h-[400px] md:h-[500px] bg-stone-900"
+    >
       <Image
         src="/images/stage.jpeg"
         alt="カラオケ喫茶コンパ ステージ"


### PR DESCRIPTION
## 概要
ハンバーガーメニューが開いた状態をVRTでキャプチャするためのStoryを追加。

## 変更内容
- `Header.stories.tsx`：`Mobile_Open` Story に `play` 関数を追加
- `KeyVisual/index.tsx`：`data-layout="KeyVisual"` を追加
- `.storybook/preview.css`：`opacity-0` の上書きを `[data-layout="KeyVisual"]` 配下にスコープを絞る

## 対応内容
- `storybook/test` の `userEvent` でボタンクリックし開いた状態を再現
- `waitFor` で開いた状態を確認後、`blur()` でフォーカスリングを除去

closes #64