### PR TITLE
【設計】店舗情報の型をオブジェクト型に変更

### DIFF
--- a/app/components/layout/Footer/index.tsx
+++ b/app/components/layout/Footer/index.tsx
@@ -2,11 +2,6 @@ import { storeInfo } from "@data/access";
 import { COPYRIGHT } from "@constants/footer";
 
 export default function Footer() {
-  const address = storeInfo.find((item) => item.label === "住所")?.value;
-  const tel = storeInfo.find((item) => item.label === "電話")?.value;
-  const hours = storeInfo.find((item) => item.label === "営業時間")?.value;
-  const holiday = storeInfo.find((item) => item.label === "定休日")?.value;
-
   return (
     <footer className="bg-stone-900 py-10 px-6 text-center">
       <div className="max-w-4xl mx-auto">
@@ -14,13 +9,14 @@ export default function Footer() {
           className="text-lg text-amber-300 mb-3"
           style={{ fontFamily: "var(--font-noto-serif)" }}
         >
-          カラオケ喫茶 コンパ
+          {storeInfo.name}
         </div>
 
         <div className="text-sm text-amber-400 leading-relaxed mb-4">
-          {address}
+          {storeInfo.address}
           <br />
-          TEL: {tel} / 営業時間: {hours} / {holiday}
+          TEL: {storeInfo.phone} / 営業時間: {storeInfo.businessHours} /{" "}
+          {storeInfo.closedDays}
         </div>
 
         <div className="text-xs text-stone-400">{COPYRIGHT}</div>

--- a/app/components/sections/Access/index.tsx
+++ b/app/components/sections/Access/index.tsx
@@ -11,7 +11,13 @@ export default function Access() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
           <dl className="text-sm">
-            {storeInfo.map((item) => (
+            {[
+              { label: "店名", value: storeInfo.name },
+              { label: "住所", value: storeInfo.address },
+              { label: "電話", value: storeInfo.phone },
+              { label: "営業時間", value: storeInfo.businessHours },
+              { label: "定休日", value: storeInfo.closedDays },
+            ].map((item) => (
               <div
                 key={item.label}
                 className="flex gap-6 border-b border-amber-100 py-3"
@@ -37,7 +43,7 @@ export default function Access() {
             allowFullScreen
             loading="lazy"
             referrerPolicy="no-referrer-when-downgrade"
-            title="カラオケ喫茶コンパの地図"
+            title={`${storeInfo.name}の地図`}
           />
         </div>
       </div>

--- a/app/data/access.ts
+++ b/app/data/access.ts
@@ -1,12 +1,9 @@
 import type { StoreInfo } from "@defs/types/access";
 
-export const storeInfo: StoreInfo[] = [
-  { label: "店名", value: "カラオケ喫茶 コンパ" },
-  {
-    label: "住所",
-    value: "〒534-0024 大阪府大阪市都島区東野田町5-7-1 千両ビル204号",
-  },
-  { label: "電話", value: "06-6928-4566" },
-  { label: "営業時間", value: "12:00〜23:00" },
-  { label: "定休日", value: "年中無休" },
-];
+export const storeInfo: StoreInfo = {
+  name: "カラオケ喫茶 コンパ",
+  address: "〒534-0024 大阪府大阪市都島区東野田町5-7-1 千両ビル204号",
+  phone: "06-6928-4566",
+  businessHours: "12:00〜23:00",
+  closedDays: "年中無休",
+};

--- a/app/defs/types/access.ts
+++ b/app/defs/types/access.ts
@@ -1,4 +1,7 @@
 export type StoreInfo = {
-  label: string;
-  value: string;
+  name: string;
+  address: string;
+  phone: string;
+  businessHours: string;
+  closedDays: string;
 };


### PR DESCRIPTION
## 概要
店舗情報の型 `StoreInfo` をラベル・バリューの配列から、各フィールドを明示的なプロパティに持つオブジェクト型に変更しました。

## issue
#69 

## 変更内容
- `StoreInfo` 型をオブジェクト型に変更（`app/defs/types/access.ts`）
- `storeInfo` データを単一オブジェクトに変更（`app/data/access.ts`）
- `Access` コンポーネントを新しい型に対応（`app/components/sections/Access/index.tsx`）
- `Footer` コンポーネントの `find` による値取得を直接参照に変更（`app/components/layout/Footer/index.tsx`）

## 背景
今後のDB統合に向けた型設計の整備。各フィールドを明示的なプロパティにすることで、型安全性と可読性が向上します。

## 確認事項
- [x] Accessセクションの表示に問題がないこと
- [x] Footerの表示に問題がないこと